### PR TITLE
fix type services from LoadBalancer to ClusterIP

### DIFF
--- a/install/cyclops-install.yaml
+++ b/install/cyclops-install.yaml
@@ -289,7 +289,7 @@ metadata:
   name: cyclops-ui
   namespace: cyclops
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: 3000
       targetPort: 80
@@ -344,7 +344,7 @@ metadata:
   labels:
     app: cyclops-ctrl
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP


### PR DESCRIPTION
fix type services from LoadBalancer to ClusterIP, this issue contains
- if your kubernetes cluster in cloud provider, you dont have to port forward services
- if your kubernetes cluster in barematal or doesnt have loadbalance, you have to change to clusterip so you portforward the services